### PR TITLE
通常実行時はデフォルトを無くし、テストの時のみgo_one.ymlを読みに行くように

### DIFF
--- a/go_one.go
+++ b/go_one.go
@@ -6,7 +6,6 @@ import (
 	"go/types"
 	"io/ioutil"
 	"log"
-	"path/filepath"
 	"sync"
 
 	"gopkg.in/yaml.v2"
@@ -99,11 +98,7 @@ var Analyzer = &analysis.Analyzer{
 var sqlTypes []types.Type
 
 func init() {
-	defaultPath, err := filepath.Abs("go_one.yml")
-	if err != nil {
-		log.Println(err)
-	}
-	Analyzer.Flags.StringVar(&configPath, "configPath", defaultPath, "config file path(abs)")
+	Analyzer.Flags.StringVar(&configPath, "configPath", "", "config file path(abs)")
 }
 
 func appendTypes(pass *analysis.Pass, pkg, name string) {

--- a/go_one_test.go
+++ b/go_one_test.go
@@ -16,6 +16,9 @@ func TestAnalyzer(t *testing.T) {
 	if err != nil {
 		log.Println(err)
 	}
-	goone.Analyzer.Flags.Set("configPath", defaultPath)
+	err = goone.Analyzer.Flags.Set("configPath", defaultPath)
+	if err != nil {
+		log.Println(err)
+	}
 	analysistest.Run(t, testdata, goone.Analyzer, "base", "separated", "gorm", "gorp", "sqlx", "user_def")
 }

--- a/go_one_test.go
+++ b/go_one_test.go
@@ -1,6 +1,8 @@
 package goone_test
 
 import (
+	"log"
+	"path/filepath"
 	"testing"
 
 	"github.com/masibw/goone"
@@ -10,5 +12,10 @@ import (
 // TestAnalyzer is base test for Analyzer.
 func TestAnalyzer(t *testing.T) {
 	testdata := analysistest.TestData()
+	defaultPath, err := filepath.Abs("go_one.yml")
+	if err != nil {
+		log.Println(err)
+	}
+	goone.Analyzer.Flags.Set("configPath", defaultPath)
 	analysistest.Run(t, testdata, goone.Analyzer, "base", "separated", "gorm", "gorp", "sqlx", "user_def")
 }


### PR DESCRIPTION
通常実行時にデフォルトが設定されているとややこしいのでテストの時のみ実行時ディレクトリのgo_one.ymlを読みに行くようにしました