### PR TITLE
Update golangci-lint to v1.29

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v1
+        uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.26
+          version: v1.29
           args: --enable=golint,gosec,prealloc,gocognit


### PR DESCRIPTION
To fix https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/ 