### PR TITLE
go getのpathを直した

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ func main(){
 
 # Install
 ```
-go get github.com/masibw/go_one/cmd/go_one
+go get github.com/masibw/goone/cmd/go_one
 ```
 
 # Usage


### PR DESCRIPTION
go.modのモジュール名を変更したせいで失敗するようになっていたのでgo getのpath表記を修正しました

before
`go get github.com/masibw/go_one/cmd/go_one`

after
`go get github.com/masibw/goone/cmd/go_one`