### PR TITLE
Remove caution

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,3 @@ package:
 # Contribute
 You're welcome to build an Issue or create a PR and be proactive!
 
-# Caution
-This tool does not support calls to functions from other packages in a for loop
-


### PR DESCRIPTION
goone now can search another package function, so this caution is not needed.