### PR TITLE
Change sqlTypes to string

### DIFF
--- a/goone_test.go
+++ b/goone_test.go
@@ -20,5 +20,5 @@ func TestAnalyzer(t *testing.T) {
 	if err != nil {
 		log.Println(err)
 	}
-	analysistest.Run(t, testdata, goone.Analyzer, "another_package", "another_package_dot", "base", "dummy_type", "gorm", "gorp", "separated", "sqlx", "user_def")
+	analysistest.Run(t, testdata, goone.Analyzer, "another_package", "another_package_dot", "base", "dummy_type", "gorm", "gorp", "separated", "sqlx", "user_def", "another_package_no_import")
 }

--- a/testdata/src/another_package_no_import/another_package_no_import.go
+++ b/testdata/src/another_package_no_import/another_package_no_import.go
@@ -1,0 +1,18 @@
+package another_package_no_import
+
+import (
+	"fmt"
+
+	"github.com/masibw/goone_test/pkg/db"
+)
+
+
+func main() {
+
+	for i:=0;i<10;i++ {
+		person := db.Person{Name:"a",JobID: 1}
+		job := db.GetJobInsideCnn(person) //want "this query is called in a loop"
+		fmt.Println(person.Name, job.Name)
+	}
+
+}


### PR DESCRIPTION
Fixed #47 

The type of the file is changed to a string so that it can be used for judgment even if it is not imported in that file.

However, since judging with strings is not accurate, I would like to change the judging method to using types in the future (the method is unknown).